### PR TITLE
Bug fix repair armor using maxDurability

### DIFF
--- a/Code/Mods/Survival/Durability.cs
+++ b/Code/Mods/Survival/Durability.cs
@@ -162,7 +162,7 @@ public class Durability : AMod
     {
         float percentReference = _repairPercentReference == RepairPercentReference.OfMissingDurability
                                ? item.MaxDurability - item.m_currentDurability
-                               : item.m_currentDurability;
+                               : item.MaxDurability;
         return flat + percent * percentReference;
     }
     private static bool HasLearnedFastMaintenance(Character character)


### PR DESCRIPTION
When using the option RepairPercentReference.OfMaxDurability.
The function CalculateDurabilityGain() should be using item.MaxDurability in favor of item.m_currentDurability.
An easy repro would be to try to repair an item with 0 durability and max durability 430.
The calculation would be:
flat (0) + percent (0.1) * percentReference (0) = 0
With this change the new calculation will be:
flat (0) + percent (0.1) * percentRefence (430) = 43